### PR TITLE
Fix docs package linking instruction and example command's code url

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Extend the `vtex` toolbelt!
 2. Clone/Create a plugin with this template.
 3. Change the template name under this project's `package.json`.
 2. Run `yarn link` on this project.
-3. Now run `vtex link @vtex/cli-plugin-template` (or the new name) on the `vtex/toolbelt` project.
+3. Now run `yarn link @vtex/cli-plugin-template` (or the new name) on the `vtex/toolbelt` project.
 4. Run `yarn watch` on the `vtex/toolbelt`
 5. Test the command on a VTEX IO app with `vtex-test hello`
 
@@ -60,5 +60,5 @@ EXAMPLE
   hello world from ./src/hello.ts!
 ```
 
-_See code: [build/commands/hello.ts](https://github.com/vtex/cli-plugin-template/blob/v0.0.0/build/commands/hello.ts)_
+_See code: [build/commands/hello.ts](https://github.com/vtex/cli-plugin-template/blob/master/src/commands/hello.ts)_
 <!-- commandsstop -->


### PR DESCRIPTION
Hey, guys! I was playing with this template and came across the following inconsistencies on the docs:

#### What is the purpose of this pull request?
- Fix the 5th instruction. Where one reads `vtex link <plugin>` should actually be `yarn link <plugin>`. 
- Updates the example command's code URL

#### Types of changes
- [x] Refactor (non-breaking change that only makes the <s>code</s> documentation better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md` (**I don't think it's necessary to make a new release for these changes. Correct me if I'm wrong :eyes:** )